### PR TITLE
关闭合并数据库的临时连接

### DIFF
--- a/db.go
+++ b/db.go
@@ -101,6 +101,7 @@ func MergeQuestions(fs ...string) {
 			log.Println("error in merge file db "+f, err.Error())
 			continue
 		}
+		defer thirdDb.Close()
 		thirdDb.View(func(thirdTx *bolt.Tx) error {
 			// Assume bucket exists and has keys
 			b := thirdTx.Bucket([]byte(QuestionBucket))


### PR DESCRIPTION
在连续自动合并数据库时，会因为上一个连接没有关闭而无限等待